### PR TITLE
routes between login pages

### DIFF
--- a/src/app/choosen-profile/page.tsx
+++ b/src/app/choosen-profile/page.tsx
@@ -1,37 +1,49 @@
 'use client'
 import React from 'react'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 import './style.css'
 import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
-import { InputSimple } from '../components/InputSimple/InputSimple'
-import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
 import Student from '../../../public/icones/student_choosen2.svg'
 import Teacher from '../../../public/icones/teacher_choosen2.svg'
 import Owner from '../../../public/icones/owner_choosen2.svg'
 
- const ChoosenProfile = () => {
+const ChoosenProfile = () => {
+
+  const router = useRouter();
+
+  const handleStudentClick = () => {
+    router.push('/student-login');
+  }
+
+  const handleTeacherClick = () => {
+    router.push('/teacher-login');
+  }
+
+  const handleOwnerClick = () => {
+    router.push('/owner-login'); 
+  }
+
   return (
     <div>
         <NavBar/>
 
         <div className='container__choosen'>
 
-            <div className='student__choosen'>
+            <div className='student__choosen' onClick={handleStudentClick}>
               <div className='container__text__choosen'>
                 <p className='choosen__title'>Estudante</p>
                 <p className='choosen__subtitle'>Clique aqui para fazer Login ou cadastrar-se</p>
                 <div className='container__img__student'>
                   <Image
-                  src={Student}
-                  alt='student choosen'
+                    src={Student}
+                    alt='student choosen'
                   />
                 </div>
               </div>  
             </div>
 
-            <div className='teacher__choosen'>
+            <div className='teacher__choosen' onClick={handleTeacherClick}>
               <div className='container__text__choosen'>
                 <p className='choosen__title'>Professor</p>
                 <p className='choosen__subtitle'>Clique aqui para fazer Login ou cadastrar-se</p>
@@ -39,12 +51,12 @@ import Owner from '../../../public/icones/owner_choosen2.svg'
                 <Image
                   src={Teacher}
                   alt='teacher choosen'
-                  />
+                />
                 </div>
               </div>  
             </div>
 
-            <div className='owner__choosen'>
+            <div className='owner__choosen' onClick={handleOwnerClick}>
               <div className='container__text__choosen'>
                 <p className='choosen__title'>Proprietário</p>
                 <p className='choosen__subtitle'>Clique aqui para fazer Login</p>
@@ -52,7 +64,7 @@ import Owner from '../../../public/icones/owner_choosen2.svg'
                 <Image
                   src={Owner}
                   alt='owner choosen'
-                  />
+                />
                 </div>
               </div>  
             </div>

--- a/src/app/forgot-password-confirm/page.tsx
+++ b/src/app/forgot-password-confirm/page.tsx
@@ -3,13 +3,18 @@ import React from 'react'
 import './style.css'
 import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
-import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
 import Pana from '../../../public/icones/forgot_password_pana.svg' 
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const ForgotPasswordConfirm = () => {
+        
+    const router = useRouter();
+
+    const handleBackClick = () => {
+      router.push('/choosen-profile');
+    }
+
   return (
     <div>
         <NavBar/>
@@ -40,7 +45,7 @@ import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
                 <p className='text__container__forgotconfirm'>Verifique seu email para redefinir sua senha. Caso não tenha chegado verifique a caixa de Spam.</p>
                 
                 <div className='button__forgotconfirm'>
-                <Button.Transparent extra style={{ width: '182px', margin:'0px'}}>Voltar</Button.Transparent>
+                <Button.Transparent extra style={{ width: '182px', margin:'0px'}}  onClick={handleBackClick}>Voltar</Button.Transparent>
                 </div>
             </div>
 

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -5,11 +5,22 @@ import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
 import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
 import Pana from '../../../public/icones/forgot_password_pana.svg' 
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const ForgotPassword = () => {
+
+    const router = useRouter();
+
+    const handleSendClick = () => {
+      router.push('/forgot-password-confirm');
+    }
+  
+    const handleCancelClick = () => {
+        router.back();
+    }
+  
+
   return (
     <div>
         <NavBar/>
@@ -45,8 +56,8 @@ import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
             </div>
 
             <div className="buttons__forgot">
-                <Button.Focused extra style={{ width: '182px', margin: '0px', marginBottom: '10px'}}>Enviar</Button.Focused>
-                <Button.Transparent extra style={{ width: '182px', margin:'0px'}}>Cancelar</Button.Transparent>      
+                <Button.Focused extra style={{ width: '182px', margin: '0px', marginBottom: '10px'}} onClick={handleSendClick}>Enviar</Button.Focused>
+                <Button.Transparent extra style={{ width: '182px', margin:'0px'}} onClick={handleCancelClick}>Cancelar</Button.Transparent>      
             </div>
         </div>
     </div>

--- a/src/app/owner-login/page.tsx
+++ b/src/app/owner-login/page.tsx
@@ -5,12 +5,22 @@ import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
 import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
 import MangooIcon from '../../../public/icones/mangoo-icon.svg'
 import Students from '../../../public/icones/school_students.svg'
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const OwnerLogin = () => {
+
+    const router = useRouter();
+
+    const handleForgotClick = () => {
+      router.push('/forgot-password');
+    }
+
+    const handleRegisterClick = () => {
+        router.push('/information');
+      }
+
   return (
     <div>
         <NavBar/>
@@ -55,14 +65,14 @@ import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
                 <p className='subtitle__text__owner'>Senha<span className='asterisk'>*</span></p>
                 <InputSimple extra placeholder='Senha' style={{ width: '380px'}}/>
 
-                <p className='password__text__owner'>Esqueceu sua senha?</p>
+                <p className='password__text__owner' onClick={handleForgotClick}>Esqueceu sua senha?</p>
 
             </div>
 
             <div className="buttons__owner">
                 <Button.Focused extra style={{ width: '350px', margin:'0px'}}>Login</Button.Focused>    
             </div>
-            <p className='footer__text__owner'>Não possui conta? Realize seu cadastro aqui</p>
+            <p className='footer__text__owner' onClick={handleRegisterClick}>Não possui conta? Realize seu cadastro aqui</p>
         </div>
     </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,10 @@ import Checkbox from "./components/CheckBox/Checkbox";
 import ProfilePhoto from "./components/ProfilePhoto/ProfilePhoto";
 import Information from "./information/page";
 import ModalContainer from "./components/Modals/ModalContainer";
-import Studentlogin from "./student-register/page";
-import TeacherLogin from "./teacher-login/page";
+import OwnerLogin from "./owner-login/page";
 
 export default function Home() {
   return (
-    <></>
+    <OwnerLogin/>
   );
 }

--- a/src/app/student-login/page.tsx
+++ b/src/app/student-login/page.tsx
@@ -5,12 +5,22 @@ import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
 import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
 import MangooIcon from '../../../public/icones/mangoo-icon.svg'
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
 import CarouselStudent from '../components/CarouselStudent/carouselstudent'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const StudentLogin = () => {
+    
+    const router = useRouter();
+
+  const handleForgotClick = () => {
+    router.push('/forgot-password');
+  }
+
+  const handleRegisterClick = () => {
+    router.push('/student-register');
+  }
+
   return (
     <div>
         <NavBar/>
@@ -48,14 +58,14 @@ import CarouselStudent from '../components/CarouselStudent/carouselstudent'
                 <p className='subtitle__text__student'>Senha<span className='asterisk'>*</span></p>
                 <InputSimple extra placeholder='Senha' style={{ width: '380px'}}/>
 
-                <p className='password__text__student'>Esqueceu sua senha?</p>
+                <p className='password__text__student' onClick={handleForgotClick}>Esqueceu sua senha?</p>
 
             </div>
 
             <div className="buttons__student">
                 <Button.Focused extra style={{ width: '350px', margin:'0px'}}>Login</Button.Focused>    
             </div>
-            <p className='footer__text__student'>Não possui conta? Realize seu cadastro aqui</p>
+            <p className='footer__text__student' onClick={handleRegisterClick}>Não possui conta? Realize seu cadastro aqui</p>
         </div>
     </div>
     </div>

--- a/src/app/student-register/page.tsx
+++ b/src/app/student-register/page.tsx
@@ -7,10 +7,17 @@ import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
 import Dropdown from "../components/Dropdown/Dropdown";
 import MangooIcon from '../../../public/icones/mangoo-icon.svg'
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
 import CarouselStudent from '../components/CarouselStudent/carouselstudent'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const StudentRegister = () => {
+
+    const router = useRouter();
+
+    const handleStudentClick = () => {
+      router.push('/student-login');
+    }
+
   return (
     <div>
         <NavBar/>
@@ -65,7 +72,7 @@ import CarouselStudent from '../components/CarouselStudent/carouselstudent'
             <div className="buttons__studentregister">
                 <Button.Focused extra style={{ width: '350px', margin:'0px'}}>Criar conta</Button.Focused>    
             </div>
-            <p className='footer__text__studentregister'>Já possui uma conta? Clique aqui</p>
+            <p className='footer__text__studentregister' onClick={handleStudentClick}>Já possui uma conta? Clique aqui</p>
         </div>
     </div>
     </div>

--- a/src/app/teacher-login/page.tsx
+++ b/src/app/teacher-login/page.tsx
@@ -5,12 +5,23 @@ import NavBar from '../components/NavBar/NavBar'
 import Image from 'next/image'
 import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
-import Dropdown from "../components/Dropdown/Dropdown";
 import MangooIcon from '../../../public/icones/mangoo-icon.svg'
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
 import CarouselTeacher from '../components/CarouselTeacher/carouselteacher'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const TeacherLogin = () => {
+       
+    const router = useRouter();
+
+  const handleForgotClick = () => {
+    router.push('/forgot-password');
+  }
+
+  const handleRegisterClick = () => {
+    router.push('/teacher-register');
+  }
+
+
   return (
     <div>
         <NavBar/>
@@ -48,14 +59,14 @@ import CarouselTeacher from '../components/CarouselTeacher/carouselteacher'
                 <p className='subtitle__text__teacher'>Senha<span className='asterisk'>*</span></p>
                 <InputSimple extra placeholder='Senha' style={{ width: '380px'}}/>
 
-                <p className='password__text__teacher'>Esqueceu sua senha?</p>
+                <p className='password__text__teacher' onClick={handleForgotClick}>Esqueceu sua senha?</p>
 
             </div>
 
             <div className="buttons__teacher">
                 <Button.Focused extra style={{ width: '350px', margin:'0px'}}>Login</Button.Focused>    
             </div>
-            <p className='footer__text__teacher'>Não possui conta? Realize seu cadastro aqui</p>
+            <p className='footer__text__teacher' onClick={handleRegisterClick}>Não possui conta? Realize seu cadastro aqui</p>
         </div>
     </div>
     </div>

--- a/src/app/teacher-register/page.tsx
+++ b/src/app/teacher-register/page.tsx
@@ -7,10 +7,17 @@ import { InputSimple } from '../components/InputSimple/InputSimple'
 import * as Button from '../components/Button/Button'
 import Dropdown from "../components/Dropdown/Dropdown";
 import MangooIcon from '../../../public/icones/mangoo-icon.svg'
-import MiddlewarePlugin from 'next/dist/build/webpack/plugins/middleware-plugin'
 import CarouselTeacher from '../components/CarouselTeacher/carouselteacher'
+import { useRouter } from 'next/navigation' // ou 'next/router' dependendo da versão
 
  const TeacherRegister = () => {
+    
+    const router = useRouter();
+
+    const handleTeacherClick = () => {
+      router.push('/teacher-login');
+    }
+
   return (
     <div>
         <NavBar/>
@@ -65,7 +72,7 @@ import CarouselTeacher from '../components/CarouselTeacher/carouselteacher'
             <div className="buttons__teacherregister">
                 <Button.Focused extra style={{ width: '350px', margin:'0px'}}>Criar conta</Button.Focused>    
             </div>
-            <p className='footer__text__teacherregister'>Já possui uma conta? Clique aqui</p>
+            <p className='footer__text__teacherregister' onClick={handleTeacherClick}>Já possui uma conta? Clique aqui</p>
         </div>
     </div>
     </div>


### PR DESCRIPTION
In this Branch, routes between the Login and Registration pages were added, so that, when clicking on "forgot password?" and "I already have a registration", the appropriate screens are shown. The Next route library was used.

![image](https://github.com/user-attachments/assets/386e05fb-5acf-4bc2-97f4-97ca4c28b1d5)
